### PR TITLE
Log parsing errors

### DIFF
--- a/jsTodoTxt.js
+++ b/jsTodoTxt.js
@@ -35,7 +35,9 @@ var TodoTxt = {
 		    i;
 		for(i = 0; i < lines.length; i++) {
 			try { items.push( new TodoTxtItem( lines[i], extensions ) ); }
-			catch ( error ) {}
+			catch ( error ) {
+				console.error(error)
+			}
 		}
 		return items;
 	},


### PR DESCRIPTION
Log parsing errors to console instead of silently ignoring them