### PR TITLE
context/project replacement patterns were too aggressive - Issue #29

### DIFF
--- a/jsTodoTxt.js
+++ b/jsTodoTxt.js
@@ -23,10 +23,10 @@ var TodoTxt = {
 	_priority_replace_re: /^\([A-Z]\)\s*/,
 
 	_context_re:         /(^|\s+)@(\S+)/g,
-	_context_replace_re: /\s*@\S+\s*/g,
+	_context_replace_re: /(^|\s+)@\S+\s*/g,
 
 	_project_re:          /(^|\s+)\+(\S+)/g,
-	_project_replace_re:  /\s*\+\S+\s*/g,
+	_project_replace_re:  /(^|\s+)\+\S+\s*/g,
 
 	/*!
 		Parse a string of lines.

--- a/jsTodoTxt.js
+++ b/jsTodoTxt.js
@@ -23,10 +23,10 @@ var TodoTxt = {
 	_priority_replace_re: /^\([A-Z]\)\s*/,
 
 	_context_re:         /(^|\s+)@(\S+)/g,
-	_context_replace_re: /(^|\s+)@\S+\s*/g,
+	_context_replace_re: /(^|\s+)@\S+/g,
 
 	_project_re:          /(^|\s+)\+(\S+)/g,
-	_project_replace_re:  /(^|\s+)\+\S+\s*/g,
+	_project_replace_re:  /(^|\s+)\+\S+/g,
 
 	/*!
 		Parse a string of lines.

--- a/test/spec/TodoTxtItem-Context.js
+++ b/test/spec/TodoTxtItem-Context.js
@@ -21,11 +21,24 @@ describe( "TodoTxtItem", function () {
 		date: null,
 		contexts: [ "Home" ],
 		projects: null
+	},
+	target_with_at_and_context = {
+		raw: "This task contains user@example.com addr. @work",
+		render: "This task contains user@example.com addr. @work",
+		text: "This task contains user@example.com addr.",
+		priority: null,
+		complete: false,
+		completed: null,
+		date: null,
+		contexts: [ "work" ],
+		projects: null
 	};
 
 	describe( "when given a context bound task", TodoTxtItemHelper( target ) );
 
 	describe( "when given a leading context bound task", TodoTxtItemHelper( leading_target ) );
+
+	describe( "when given a task containing @ and a context", TodoTxtItemHelper( target_with_at_and_context ) );
 
 	var invalid = [
 		// Whitespace is required in front of the context

--- a/test/spec/TodoTxtItem-Project.js
+++ b/test/spec/TodoTxtItem-Project.js
@@ -11,7 +11,7 @@ describe( "TodoTxtItem", function () {
 		contexts: null,
 		projects: [ "Project" ]
 	},
-  leading_target = {
+	leading_target = {
 		raw: "+Project This is a task.",
 		render: "This is a task. +Project",
 		text: "This is a task.",
@@ -21,6 +21,17 @@ describe( "TodoTxtItem", function () {
 		date: null,
 		contexts: null,
 		projects: [ "Project" ]
+	},
+	target_with_plus_and_project = {
+		raw: "This task contains 2+2=4 and a+b. +Manhattan",
+		render: "This task contains 2+2=4 and a+b. +Manhattan",
+		text: "This task contains 2+2=4 and a+b.",
+		priority: null,
+		complete: false,
+		completed: null,
+		date: null,
+		contexts: null,
+		projects: [ "Manhattan" ]
 	};
 
 	var invalid = [
@@ -33,6 +44,8 @@ describe( "TodoTxtItem", function () {
 	describe( "when given a project task", TodoTxtItemHelper( target ) );
 
 	describe( "when given a leading project task", TodoTxtItemHelper( leading_target ) );
+
+	describe( "when given a task containing + and a project", TodoTxtItemHelper( target_with_plus_and_project ) );
 
 	describe( "when given an invalid project string", function () {
 		it( "should not parse it", function () {


### PR DESCRIPTION
This change should fix issue #29, by making the `_context_replace_re` and `_project_replace_re` a bit less aggressive.  The new patterns make sure that an `@` or `+` is preceded by space or start of line before matching and removing the following word.  To repro the issue, you could try something like:

```
here is some text a+b 2+2=4 and here is a +project
```
Similarly for embedded `@` in lines that contain a true `@context`.