### PR TITLE
Possible extensions system for 1.0.0

### DIFF
--- a/src/Extensions.ts
+++ b/src/Extensions.ts
@@ -1,0 +1,24 @@
+import { Item } from './Item';
+
+export interface Extension {}
+
+export type ExtensionFactory = (item: Item, key: string, value: string) => Extension|null;
+
+const register = new Map<string, ExtensionFactory>();
+
+export function RegisterExtension(keys: string[], parsingFunction:ExtensionFactory) {
+	for (const key of keys) {
+		if(register.has(key)) {
+			throw new Error(`An extension handler for "${key}" is already registered.`);
+		}
+		register.set(key, parsingFunction);
+	}
+}
+
+export function NewExtension(item: Item, key: string, value: string):Extension|null {
+	const fn = register.get(key);
+	if(typeof fn !== 'undefined') {
+		return fn(item, key, value);
+	}
+	return null;
+}

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -1,3 +1,5 @@
+import { Extension as ExtensionClass, NewExtension } from './Extensions';
+
 const rTodo = /^((x) )?(\(([A-Z])\) )?(((\d{4}-\d{2}-\d{2}) (\d{4}-\d{2}-\d{2})|(\d{4}-\d{2}-\d{2})) )?(.*)$/;
 const rTags = /([^\s:]+:[^\s:]+|[+@]\S+)/g;
 const rDate = /^\d{4}-\d{2}-\d{2}$/;
@@ -20,6 +22,7 @@ interface Extension {
 		key: string
 		value: string
 	}
+	object: ExtensionClass|null
 	span: Span
 }
 
@@ -161,7 +164,7 @@ export class Item {
 		const str = this.toString()
 		const headerLength = str.length - this.#body.length;
 
-		function tagRemap (prefix:string) {
+		const tagRemap = (prefix:string) => {
 			return function(tag:TrackedTag):Tag {
 				const fullTag = [prefix, tag.tag].join('');
 				return {
@@ -174,10 +177,12 @@ export class Item {
 			};
 		}
 
-		function extensionsRemap (ext:TrackedExtension):Extension {
+		const extensionsRemap = (ext:TrackedExtension):Extension => {
 			const tag = `${ext.key}:${ext.value}`;
+
 			return {
 				string: tag,
+				object: NewExtension(this, ext.key, ext.value),
 				parsed: {
 					key: ext.key,
 					value: ext.value,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './Item'
+export { RegisterExtension, Extension, ExtensionFactory } from './Extensions';


### PR DESCRIPTION
With the rewrite, I'm looking to support #10.

This is roughly the proposed API.  Due to the check and cast when using, I'm uncertain this is any better than having users manage extensions outside of the core.

### Example Usage

```typescript
import { Item, Extension, RegisterExtension } from './src/index';

class HiddenExtension {
	#item: Item
	#hidden: boolean

	constructor(item: Item, value: string) {
		this.#hidden = value === '1';
		this.#item = item;
	}

	isHidden():boolean {
		return this.#hidden;
	}

	hide() {
		this.#hidden = true;
		this.#item.setExtension('h', '1');
	}

	unhide() {
		this.#hidden = false;
		this.#item.setExtension('h', '0');
	}
}

RegisterExtension(
	['h'],
	(item: Item, _: string, value: string):Extension => { 
		return new HiddenExtension(item, value);
	}
);

const item = new Item('This is hidden. h:1');

console.log(item.extensions());
// [ { key: 'h', value: '1' } ]

const annotated = item.toAnnotatedString();
console.log(annotated);
/*
{
  string: 'This is hidden. h:1',
  contexts: [],
  projects: [],
  extensions: [
    {
      string: 'h:1',
      object: HiddenExtension {},
      parsed: [Object],
      span: [Object]
    }
  ]
}
*/

annotated.extensions.forEach(ext => {
	if(ext.parsed.key === 'h' && ext.object !== null)  {
		(ext.object as HiddenExtension).unhide();
	}
})
console.log(item.extensions());
// [ { key: 'h', value: '0' } ]

console.log(item.toString());
// This is hidden. h:0
```