### PR TITLE
fix: tags need to be prefixed by a whitespace

### DIFF
--- a/src/Item.contexts.test.ts
+++ b/src/Item.contexts.test.ts
@@ -9,6 +9,11 @@ test('contexts › Deduplicated', (t) => {
 	t.deepEqual(item.contexts(), ['home', 'work']);
 });
 
+test('contexts › Does not parse email as context', (t) => {
+	const item = new Item('My email is me@example.com , it is not a context');
+	t.deepEqual(item.contexts(), []);
+});
+
 test('addContext › Adds new contexts', (t) => {
 	const item = new Item(sampleCompleted);
 	item.addContext('computer');

--- a/src/Item.projects.test.ts
+++ b/src/Item.projects.test.ts
@@ -9,6 +9,11 @@ test('projects › Deduplicates', (t) => {
 	t.deepEqual(item.projects(), ['goals', 'projects']);
 });
 
+test('projects › Does not parse context without a space', (t) => {
+	const item = new Item('A small computation: 1+1 = 2');
+	t.deepEqual(item.projects(), []);
+});
+
 test('addProject › Adds new projects', (t) => {
 	const item = new Item(sampleCompleted);
 	item.addProject('rewrite');

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -1,6 +1,6 @@
 const rTodo =
 	/^((x) )?(\(([A-Z])\) )?(((\d{4}-\d{2}-\d{2}) (\d{4}-\d{2}-\d{2})|(\d{4}-\d{2}-\d{2})) )?(.*)$/;
-const rTags = /([^\s:]+:[^\s:]+|[+@]\S+)/g;
+const rTags = /\s([^\s:]+:[^\s:]+|[+@]\S+)/g;
 const rDate = /^\d{4}-\d{2}-\d{2}$/;
 
 // External types
@@ -54,13 +54,15 @@ type TrackedProject = TrackedTag;
 
 function parseBody(body: string) {
 	let start = 0;
-	const tags = (body.match(rTags) || []).map((tag): [string, number] => {
-		const tagStart = body.indexOf(tag, start);
-		if (tagStart != -1) {
-			start = tagStart + tag.length;
-		}
-		return [tag, tagStart];
-	});
+	const tags = (body.match(rTags) || [])
+		.map((tag) => tag.trimStart())
+		.map<[string, number]>((tag) => {
+			const tagStart = body.indexOf(tag, start);
+			if (tagStart != -1) {
+				start = tagStart + tag.length;
+			}
+			return [tag, tagStart];
+		});
 
 	const contexts: TrackedContext[] = [];
 	const projects: TrackedProject[] = [];


### PR DESCRIPTION
A simple fix to prevent parsing of non projects tags (ex: `1+1`) and email as context. I simply added a whitespace in the regex `rTags` and added some tests

fix #51 