### PR TITLE
fix: complete a task without creation date

### DIFF
--- a/src/Item.completed.test.ts
+++ b/src/Item.completed.test.ts
@@ -7,7 +7,18 @@ test('setCompleted › Adding with Date', (t) => {
 	item.setCompleted(due);
 	t.deepEqual(item.completed(), due);
 	t.true(item.complete());
+	t.is(item.createdToString(), '2022-06-29');
 	t.is(item.toString(), 'x 2022-07-01 2022-06-29 I have to do this.');
+});
+
+test('setCompleted › Set a task completed without a creating date ', (t) => {
+	const item = new Item('I have to do this.');
+	const due = new Date(2022, 6, 1);
+	item.setCompleted(due);
+	t.deepEqual(item.completed(), due);
+	t.true(item.complete());
+	t.is(item.created(), null);
+	t.is(item.toString(), 'x 2022-07-01 I have to do this.');
 });
 
 test('setCompleted › Adding with string', (t) => {

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -329,19 +329,15 @@ export class Item {
 	 *
 	 * @param date
 	 * @throws An Error when the date is provided as a string and is invalid.
-	 * @throws An Error when the created date is not set.
 	 */
 	setCompleted(date: Date | string | null = null) {
 		if (date === null) {
 			this.clearCompleted();
 		} else {
-			if (this.#created === null) {
-				throw new Error('Can not set completed date without a created date set.');
-			}
 			if (date instanceof Date) {
-				this.#completed = <Date | null>date;
+				this.#completed = date;
 			} else {
-				this.#completed = dateFromString(<string>date);
+				this.#completed = dateFromString(date);
 			}
 			this.#complete = true;
 		}


### PR DESCRIPTION
fix #50 

I fix we can completly remove the error `throw new Error('Can not set completed date without a created date set.');`. Tests pass and I also added aditional tests to be sure