### PR TITLE
perf: improve list tags performances

### DIFF
--- a/src/List.context.test.ts
+++ b/src/List.context.test.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import { List } from './List';
+
+test('context › get contexts', (t) => {
+	const list = new List('first item @context-1\nsecond item @context-2');
+	t.deepEqual(list.contexts(), ['context-1', 'context-2']);
+});
+
+test('context › deduplicate', (t) => {
+	const list = new List('first item @context-1\nsecond item @context-1');
+	t.deepEqual(list.contexts(), ['context-1']);
+});

--- a/src/List.extensions.test.ts
+++ b/src/List.extensions.test.ts
@@ -1,0 +1,17 @@
+import test from 'ava';
+import { List } from './List';
+
+test('extensions › get extensions', (t) => {
+	const list = new List('first item ext-1:value-1\nsecond item ext-2:value-2');
+	t.deepEqual(list.extensions(), {
+		'ext-1': ['value-1'],
+		'ext-2': ['value-2'],
+	});
+});
+
+test('extensions › deduplicate', (t) => {
+	const list = new List('first item ext-1:value-1\nsecond item ext-1:value-1 ext-1:value-2');
+	t.deepEqual(list.extensions(), {
+		'ext-1': ['value-1', 'value-2'],
+	});
+});

--- a/src/List.projects.test.ts
+++ b/src/List.projects.test.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import { List } from './List';
+
+test('projects › get projects', (t) => {
+	const list = new List('first item +project-1\nsecond item +project-2');
+	t.deepEqual(list.projects(), ['project-1', 'project-2']);
+});
+
+test('projects › deduplicate', (t) => {
+	const list = new List('first item +project-1\nsecond item +project-1');
+	t.deepEqual(list.projects(), ['project-1']);
+});

--- a/src/List.ts
+++ b/src/List.ts
@@ -62,29 +62,41 @@ export class List {
 	}
 
 	projects(): string[] {
-		return [
-			...new Set(this.#items.map((item) => item.projects()).reduce((p, n) => [...p, ...n], [])),
-		];
+		const projects = new Set<string>();
+
+		for (const item of this.#items) {
+			item.projects().forEach((p) => projects.add(p));
+		}
+
+		return [...projects];
 	}
 
 	contexts(): string[] {
-		return [
-			...new Set(this.#items.map((item) => item.contexts()).reduce((p, n) => [...p, ...n], [])),
-		];
+		const context = new Set<string>();
+
+		for (const item of this.#items) {
+			item.contexts().forEach((c) => context.add(c));
+		}
+
+		return [...context];
 	}
 
 	extensions(): KeysForExtensions {
-		const ret: KeysForExtensions = {};
+		const extensionsSets = this.#items
+			.flatMap((i) => i.extensions())
+			.reduce<Record<string, Set<string>>>((acc, { key, value }) => {
+				if (acc[key] === undefined) {
+					acc[key] = new Set([value]);
+				} else {
+					acc[key].add(value);
+				}
+				return acc;
+			}, {});
 
-		this.#items.forEach((item) => {
-			item.extensions().forEach((ext) => {
-				const values = ret[ext.key] || [];
-				values.push(ext.value);
-				ret[ext.key] = [...new Set(values)];
-			});
-		});
-
-		return ret;
+		return Object.entries(extensionsSets).reduce<KeysForExtensions>((acc, [key, value]) => {
+			acc[key] = [...value];
+			return acc;
+		}, {});
 	}
 
 	filter(input: ListFilter): ListItem[] {


### PR DESCRIPTION
using reduce to create a new array at each loop consume more memory than reusing the same array.

So I just avoid it on `List.context`, `List.projects` and `List.extensions` to improve that. It's a micro-optimisation, but I think it can make a noticable difference on big files like `done.txt`

I also added some tests.