### PR TITLE
fix: tags need to be prefixed by a whitespace

### DIFF
--- a/src/Item.contexts.test.ts
+++ b/src/Item.contexts.test.ts
@@ -9,6 +9,11 @@ test('contexts › Deduplicated', (t) => {
 	t.deepEqual(item.contexts(), ['home', 'work']);
 });
 
+test('contexts › Does not parse email as context', (t) => {
+	const item = new Item('My email is me@example.com , it is not a context');
+	t.deepEqual(item.contexts(), []);
+});
+
 test('addContext › Adds new contexts', (t) => {
 	const item = new Item(sampleCompleted);
 	item.addContext('computer');

--- a/src/Item.contexts.test.ts
+++ b/src/Item.contexts.test.ts
@@ -10,8 +10,13 @@ test('contexts › Deduplicated', (t) => {
 });
 
 test('contexts › Does not parse email as context', (t) => {
-	const item = new Item('My email is me@example.com , it is not a context');
+	const item = new Item('My email is me@example.com it is not a context');
 	t.deepEqual(item.contexts(), []);
+});
+
+test('contexts › Parses context at start of line', (t) => {
+	const item = new Item('@home wash the dishes');
+	t.deepEqual(item.contexts(), ['home']);
 });
 
 test('addContext › Adds new contexts', (t) => {
@@ -48,4 +53,11 @@ test('removeContext › Updates the body', (t) => {
 	const item = new Item('Hello @home and @work with +projects and @work extensions:todo');
 	item.removeContext('work');
 	t.is(item.body(), 'Hello @home and with +projects and extensions:todo');
+});
+
+test('contexts › Does not parse email addresses', (t) => {
+	const item = new Item(
+		'me@example.com Hello @home and name@example.com with +projects extensions:todo'
+	);
+	t.deepEqual(item.contexts(), ['home']);
 });

--- a/src/Item.extensions.test.ts
+++ b/src/Item.extensions.test.ts
@@ -1,6 +1,15 @@
 import test from 'ava';
 import { Item } from './Item';
 
+test('extensions › Reads extensions', (t) => {
+	const item = new Item('due:today Hello there extensions:todo and color:red');
+	t.deepEqual(item.extensions(), [
+		{ key: 'due', value: 'today' },
+		{ key: 'extensions', value: 'todo' },
+		{ key: 'color', value: 'red' },
+	]);
+});
+
 test('setExtension › Overwrites existing values', (t) => {
 	const item = new Item('Party like its due:2022-10-22');
 	item.setExtension('due', '1999-12-31');

--- a/src/Item.projects.test.ts
+++ b/src/Item.projects.test.ts
@@ -9,6 +9,11 @@ test('projects › Deduplicates', (t) => {
 	t.deepEqual(item.projects(), ['goals', 'projects']);
 });
 
+test('projects › Does not parse context without a space', (t) => {
+	const item = new Item('A small computation: 1+1 = 2');
+	t.deepEqual(item.projects(), []);
+});
+
 test('addProject › Adds new projects', (t) => {
 	const item = new Item(sampleCompleted);
 	item.addProject('rewrite');

--- a/src/Item.projects.test.ts
+++ b/src/Item.projects.test.ts
@@ -14,6 +14,11 @@ test('projects › Does not parse context without a space', (t) => {
 	t.deepEqual(item.projects(), []);
 });
 
+test('projects › Parses context at start of line', (t) => {
+	const item = new Item('+goals Do the thing');
+	t.deepEqual(item.projects(), ['goals']);
+});
+
 test('addProject › Adds new projects', (t) => {
 	const item = new Item(sampleCompleted);
 	item.addProject('rewrite');

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -1,6 +1,6 @@
 const rTodo =
 	/^((x) )?(\(([A-Z])\) )?(((\d{4}-\d{2}-\d{2}) (\d{4}-\d{2}-\d{2})|(\d{4}-\d{2}-\d{2})) )?(.*)$/;
-const rTags = /([^\s:]+:[^\s:]+|[+@]\S+)/g;
+const rTags = /\s([^\s:]+:[^\s:]+|[+@]\S+)/g;
 const rDate = /^\d{4}-\d{2}-\d{2}$/;
 
 // External types
@@ -54,13 +54,15 @@ type TrackedProject = TrackedTag;
 
 function parseBody(body: string) {
 	let start = 0;
-	const tags = (body.match(rTags) || []).map((tag): [string, number] => {
-		const tagStart = body.indexOf(tag, start);
-		if (tagStart != -1) {
-			start = tagStart + tag.length;
-		}
-		return [tag, tagStart];
-	});
+	const tags = (body.match(rTags) || [])
+		.map((tag) => tag.trimStart())
+		.map<[string, number]>((tag) => {
+			const tagStart = body.indexOf(tag, start);
+			if (tagStart != -1) {
+				start = tagStart + tag.length;
+			}
+			return [tag, tagStart];
+		});
 
 	const contexts: TrackedContext[] = [];
 	const projects: TrackedProject[] = [];

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -1,6 +1,10 @@
 const rTodo =
 	/^((x) )?(\(([A-Z])\) )?(((\d{4}-\d{2}-\d{2}) (\d{4}-\d{2}-\d{2})|(\d{4}-\d{2}-\d{2})) )?(.*)$/;
-const rTags = /\s([^\s:]+:[^\s:]+|[+@]\S+)/g;
+
+// A regex to match all tags (context, priority or extensions)
+const rTags = /(^|\s)([^\s:]+:[^\s:]+|[+@]\S+)/g;
+
+// A regex to match dates valid in the todo.txt spec
 const rDate = /^\d{4}-\d{2}-\d{2}$/;
 
 // External types


### PR DESCRIPTION
Tweaked fix from #55

> A simple fix to prevent parsing of non projects tags (ex: 1+1) and email as context. I simply added a whitespace in the regex rTags and added some tests
> 
> fix https://github.com/jmhobbs/jsTodoTxt/issues/51